### PR TITLE
Fix SQL query to use wildcard for book name search

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE %s", name
+           "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
This pull request updates the way books are queried by name in the `index` function of `server/routes.py`. Instead of using a parameterized SQL query, it now directly interpolates the `name` variable into the SQL string.

Database query modification:

* Changed the SQL query in the `index` function to use string interpolation for the `name` parameter, constructing the query as `"SELECT * FROM books WHERE name LIKE '%" + name + "%'"` instead of using parameterized queries.