### PR TITLE
Potential fix for code scanning alert no. 1: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-           "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
+           "SELECT * FROM books WHERE name LIKE %s", "%" + name + "%"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/fatihdurgut/skills-introduction-to-codeql/security/code-scanning/1](https://github.com/fatihdurgut/skills-introduction-to-codeql/security/code-scanning/1)

To fix the problem, all SQL queries using user-provided input must use query parameters (i.e., prepared statements and placeholders) rather than string concatenation. In this case, rather than constructing `"SELECT * FROM books WHERE name LIKE '%" + name + "%'"`, the query should pass the pattern as a parameter, using the database connector’s parameter substitution syntax (here, `%s`).  
Edit lines 15–17 to:  
- Change the SQL statement to `"SELECT * FROM books WHERE name LIKE %s"`.
- Pass the LIKE pattern as a second argument to `cursor.execute`, e.g., `f"%{name}%"` or `"%" + name + "%"`.
No other code changes are required. No new imports are needed, as parameterized queries are supported by standard DB API and the rest of the file already imports what it requires.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
